### PR TITLE
Monitor input/output rates instead of displaying index ticks

### DIFF
--- a/tests/Spreads.Tests/CircularTests.fs
+++ b/tests/Spreads.Tests/CircularTests.fs
@@ -17,7 +17,7 @@ type CircularTestsModule() =
     
   [<Test>]
   member this.``Circular Calculations Work``() =
-    let numQuoteSources = 2
+    let numQuoteSources = 100
 
     let cts = new CancellationTokenSource()
     let ct = cts.Token
@@ -53,10 +53,14 @@ type CircularTestsModule() =
         Async.Start(task, ct)
         sm :> Series<DateTime, float>
 
-    let arrayOfContinuousSeries = Array.init numQuoteSources (fun i -> (makeQuoteSource ()).Repeat())
+    let quoteSources = 
+        Array.init numQuoteSources (fun i -> let qs = makeQuoteSource()
+                                             // make the 1st quotesource discrete, the rest continuous
+                                             if i = 0 then qs else qs.Repeat()
+                                             )
 
     let index : Series<DateTime, float> = 
-        arrayOfContinuousSeries.Zip(fun k vArr -> vArr |> Array.average)
+        quoteSources.Zip(fun k vArr -> vArr |> Array.average)
 
     // monitoring - 2s chunks, and total
     let chunkMillisecs = 2000

--- a/tests/Spreads.Tests/CircularTests.fs
+++ b/tests/Spreads.Tests/CircularTests.fs
@@ -23,6 +23,12 @@ type CircularTestsModule() =
     let ct = cts.Token
     let rng = System.Random()
 
+    // monitoring variables
+    let totalOutputs = ref 0
+    let chunkOutputs = ref 0
+    let totalInputs = ref 0
+    let chunkInputs = ref 0
+
     let makeQuoteSource () : Series<DateTime, float> = // data is produced outside
         let mutable value = 1.0
         let sm = SortedMap()
@@ -32,13 +38,13 @@ type CircularTestsModule() =
         let gapMillisecs = int(rng.NextDouble() * 500.0 + 250.0)
 
         sm.Add(now, value)
-        cnt <- cnt + 1
-        if cnt % 40 = 0 then trend <- -trend
 
         let task = async {
                         while not ct.IsCancellationRequested do
                             do! Async.Sleep gapMillisecs
                             let time = DateTime.UtcNow
+                            Interlocked.Increment(totalInputs) |> ignore
+                            Interlocked.Increment(chunkInputs) |> ignore
                             value <- value*(1.0 + rng.NextDouble()*0.002 - 0.001 + 0.001 * trend)
                             sm.Add(time, value)
                             cnt <- cnt + 1
@@ -52,8 +58,33 @@ type CircularTestsModule() =
     let index : Series<DateTime, float> = 
         arrayOfContinuousSeries.Zip(fun k vArr -> vArr |> Array.average)
 
+    // monitoring - 2s chunks, and total
+    let chunkMillisecs = 2000
+    let totalStopwatch = new Diagnostics.Stopwatch()
+    let chunkStopwatch = new Diagnostics.Stopwatch()
+    totalStopwatch.Start()
+    chunkStopwatch.Start()
+
+    let printRates (stopwatch : Diagnostics.Stopwatch) inputs outputs =
+        let elapsedSeconds = (float)stopwatch.ElapsedMilliseconds / 1000.
+        printfn "%A: %d inputs (%f/s) -> %d outputs (%f/s)" DateTime.UtcNow inputs (((float)inputs)/elapsedSeconds) outputs (((float)outputs)/elapsedSeconds) 
+
+    let monitor = async {
+                        while not ct.IsCancellationRequested do
+                            do! Async.Sleep chunkMillisecs
+                            let inputs = Interlocked.Exchange(chunkInputs, 0)
+                            let outputs = Interlocked.Exchange(chunkOutputs, 0)
+                            printRates chunkStopwatch inputs outputs
+                            chunkStopwatch.Restart()
+                        printfn "Total:"
+                        printRates totalStopwatch !totalInputs !totalOutputs
+                        }
+    Async.Start(monitor, ct)
+
     index.Do((fun k v -> 
-                printfn "Index: %A = %f" k v
+                // just count the outputs
+                Interlocked.Increment(chunkOutputs) |> ignore
+                Interlocked.Increment(totalOutputs) |> ignore
                 ), ct)
 
     Thread.Sleep(10000000)


### PR DESCRIPTION
This avoids flooding stdout with index results when you increase the number of quotesources