### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ every point. But this works without allocating memory and also works in real-tim
 data.
 
 
-##Install
+## Install
 
     PM> Install-Package Spreads
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
